### PR TITLE
[FEAT] : 데이터 연동용 wrapper method 구현

### DIFF
--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,0 +1,89 @@
+import axios, { type AxiosResponse } from 'axios';
+
+interface PostRequestParams<TData> {
+  request: string;
+  headers?: { [key: string]: string };
+  data?: TData;
+}
+
+interface DeleteRequestParams {
+  request: string;
+  headers?: { [key: string]: string };
+}
+
+interface GetRequestParams<TParams> {
+  request: string;
+  headers?: { [key: string]: string };
+  params?: TParams;
+}
+
+const instance = axios.create({
+  baseURL: 'http://localhost:8080',
+});
+
+export async function get<TResponse, TParams = unknown>(
+  config: GetRequestParams<TParams>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, params } = config;
+  try {
+    const response = await instance.get<TResponse>(request, {
+      withCredentials: true,
+      params: params,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function post<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, data, headers } = config;
+  try {
+    const response = await instance.post<TResponse, AxiosResponse<TResponse>, TData>(request, data, {
+      withCredentials: true,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function put<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, data, headers } = config;
+  try {
+    const response = await instance.put<TResponse, AxiosResponse<TResponse>, TData>(request, data, {
+      withCredentials: true,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function del<TResponse = unknown>(config: DeleteRequestParams): Promise<AxiosResponse<TResponse>> {
+  const { request, headers } = config;
+  try {
+    const response = await instance.delete<TResponse, AxiosResponse<TResponse>>(request, {
+      withCredentials: true,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}

--- a/src/shared/api/index.ts
+++ b/src/shared/api/index.ts
@@ -1,0 +1,2 @@
+export * from './axios';
+export * from './request';

--- a/src/shared/api/request.ts
+++ b/src/shared/api/request.ts
@@ -1,0 +1,5 @@
+export const REQUEST = {
+  LOGIN: '/api/v1/members/sign-in',
+  REGISTER: '/api/v1/members/sign-up',
+  GET_USER_INFO: '/api/v1/members/current-user',
+};

--- a/src/widgets/login/api/index.ts
+++ b/src/widgets/login/api/index.ts
@@ -1,0 +1,1 @@
+export * from './submitLogin';

--- a/src/widgets/login/api/submitLogin.ts
+++ b/src/widgets/login/api/submitLogin.ts
@@ -1,0 +1,18 @@
+import { post } from '@/shared/api';
+import { REQUEST } from '@/shared/api/request';
+import { useMutation } from '@tanstack/react-query';
+import type { Login } from '../types';
+
+const submitLogin = async ({ email, password }: Login) => {
+  const response = await post<Login>({
+    request: REQUEST.LOGIN,
+    data: { email: email, password: password },
+  });
+  return response.data;
+};
+
+export const useSubmitLogin = () => {
+  return useMutation({
+    mutationFn: submitLogin,
+  });
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #13

## 📝 작업 내용

> 백엔드와 데이터를 연동할 때 사용할 수 있는 wrapper method를 구현하고 baseUrl을 세팅했습니다.
- `post`, `put`, `delete`, `get` 메서드를 구현해두었습니다. 
- 자세한 사용 방법은 메서드 정의 파일 참고해주시면 될 것 같아요.
- 사용 예시는 다음과 같습니다.
```
const submitLogin = async ({ email, password }: Login) => {
  const response = await post<Login>({
    request: REQUEST.LOGIN,
    data: { email: email, password: password },
  });
  return response.data;
};
```
- 저의 경우 이렇게 wrapper method를 사용한 데이터 패칭 비동기 함수를 생성한 뒤, 데이터 상태 관리를 위해 tanstack query의 `useQuery` 또는 `useMutation`을 사용합니다. 이들을 사용하기 위해서는 동일 파일 아래에 커스텀 훅을 생성하고 정의한 함수를 사용하는 `useQuery` 또는 `useMutation`을 리턴해 주면 됩니다.
```
export const useSubmitLogin = () => {
  return useMutation({
    mutationFn: submitLogin,
  });
};
```
```
// mutation 사용은 이렇게
const { mutate } = useSubmitLogin();
mutate({email: '', password: ''});

// query 사용은 이렇게

const { isPending, data, refetch } = useFetchUserInfo();
console.log(data);
```
- 위 코드들은 제가 샘플로 구현해둔 `/widgets/login/api/submitLogin.ts` 의 내용입니다. 참고해서 구현해 주시면 좋을 것 같아요.
- 요청 엔드포인트는 관리 용이성을 위해 `request.ts` 파일 내부에서 상수로 정의하고 사용합니다.
- 데이터 패칭 함수들은 REST API 규칙에 따라 아래와 같은 네이밍 컨벤션을 갖도록 합니다.

| HTTP 메서드 | 목적         | 함수 이름 예시(이름앞에 붙여주세요) | 설명                          |
|-------------|--------------|----------------|-------------------------------|
| GET         | 데이터 조회  | `fetch`, ex) `fetchUserInfo`        | 데이터를 가져올 때 사용       |
| POST        | 데이터 생성  | `submit`, ex) `submitUserInfo`       | 새 데이터를 보낼 때 사용      |
| PUT   | 데이터 수정  | `update`, ex) `updatePostDetail`       | 기존 데이터를 수정할 때 사용  |
| DELETE      | 데이터 삭제  | `delete`, ex) `deletePost`       | 데이터를 삭제할 때 사용       |

## 📸 스크린샷
