### PR TITLE
[FEAT] : 로그인, 회원가입 기능 연동

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,6 +21,7 @@ export default [
         document: 'readonly',
         window: 'readonly',
         console: 'readonly',
+        alert: 'readonly',
         setTimeout: 'readonly',
         clearTimeout: 'readonly',
         setInterval: 'readonly',

--- a/src/routes/_homeLayout.tsx
+++ b/src/routes/_homeLayout.tsx
@@ -1,8 +1,18 @@
+import { PATH } from '@/shared/constants';
+import { fetchLoginStatus } from '@/shared/utils';
 import { container, mainContent } from '@/shared/styles/container.css';
 import { ChannelSelector, Header, SideBar, UserInfo } from '@/widgets/menu/ui';
-import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Outlet, createFileRoute, redirect } from '@tanstack/react-router';
 
 export const Route = createFileRoute('/_homeLayout')({
+  beforeLoad: () => {
+    const isAuthenticated = fetchLoginStatus();
+    if (!isAuthenticated) {
+      throw redirect({
+        to: PATH.LOGIN,
+      });
+    }
+  },
   component: () => (
     <div className={container}>
       <Header />

--- a/src/shared/api/user.ts
+++ b/src/shared/api/user.ts
@@ -1,0 +1,110 @@
+import axios, { type AxiosHeaders, type AxiosResponse } from 'axios';
+import { getCookie } from '../utils/cookie';
+
+interface PostRequestParams<TData> {
+  request: string;
+  headers?: AxiosHeaders | { [key: string]: string };
+  data?: TData;
+}
+
+interface GetRequestParams<TParams> {
+  request: string;
+  headers?: AxiosHeaders;
+  params?: TParams;
+}
+
+const instance = axios.create({
+  baseURL: 'http://localhost:8080',
+});
+
+instance.interceptors.request.use(async (config) => {
+  if (typeof window !== 'undefined') {
+    const stored = getCookie('accessToken');
+    if (stored) {
+      const accessToken = stored;
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+  }
+  return config;
+});
+
+export async function userGet<TResponse, TParams = unknown>(
+  config: GetRequestParams<TParams>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, params } = config;
+  try {
+    const response = await instance.get<TResponse>(request, {
+      params: params,
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userPost<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.post<TResponse, AxiosResponse<TResponse>, TData>(request, data, {
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userPut<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.put<TResponse, AxiosResponse<TResponse>, TData>(request, data, {
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userDel<TResponse = unknown>(
+  config: Omit<PostRequestParams<unknown>, 'data'>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers } = config;
+  try {
+    const response = await instance.delete<TResponse, AxiosResponse<TResponse>>(request, {
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}
+
+export async function userPatch<TData, TResponse = unknown>(
+  config: PostRequestParams<TData>
+): Promise<AxiosResponse<TResponse>> {
+  const { request, headers, data } = config;
+  try {
+    const response = await instance.patch<TResponse, AxiosResponse<TResponse>, TData>(request, data, {
+      headers: headers || undefined,
+    });
+    return response;
+  } catch (error: unknown) {
+    console.log(error);
+    if (axios.isAxiosError(error)) throw new Error(error.response?.data.message);
+    else throw new Error('에러가 발생했습니다');
+  }
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,1 @@
+export * from './token';

--- a/src/shared/types/token.ts
+++ b/src/shared/types/token.ts
@@ -1,0 +1,4 @@
+export type Token = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/src/shared/utils/cookie.ts
+++ b/src/shared/utils/cookie.ts
@@ -1,0 +1,16 @@
+export const getCookie = (name: string) => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return decodeURIComponent(parts.pop()?.split(';').shift() || '');
+};
+
+export const setCookie = (name: string, value: string, days: number) => {
+  const date = new Date();
+  date.setTime(date.getTime() + days * 24 * 60 * 60 * 1000);
+  const expires = `expires=${date.toUTCString()}`;
+  document.cookie = `${name}=${encodeURIComponent(value)}; ${expires}; path=/`;
+};
+
+export const deleteCookie = (name: string) => {
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+};

--- a/src/shared/utils/fetchLoginStatus.ts
+++ b/src/shared/utils/fetchLoginStatus.ts
@@ -1,0 +1,7 @@
+import { getCookie } from './cookie';
+
+export const fetchLoginStatus = () => {
+  const accessToken = getCookie('accessToken');
+
+  return !!accessToken;
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './cookie';

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './cookie';
+export * from './fetchLoginStatus';

--- a/src/widgets/login/api/submitLogin.ts
+++ b/src/widgets/login/api/submitLogin.ts
@@ -2,9 +2,10 @@ import { post } from '@/shared/api';
 import { REQUEST } from '@/shared/api/request';
 import { useMutation } from '@tanstack/react-query';
 import type { Login } from '../types';
+import type { Token } from '@/shared/types';
 
 const submitLogin = async ({ email, password }: Login) => {
-  const response = await post<Login>({
+  const response = await post<Login, Token>({
     request: REQUEST.LOGIN,
     data: { email: email, password: password },
   });

--- a/src/widgets/login/ui/LoginForm.tsx
+++ b/src/widgets/login/ui/LoginForm.tsx
@@ -7,12 +7,26 @@ import FormInput from '@/shared/components/FormInput';
 import Button from '@/shared/components/Button';
 import { useForm } from 'react-hook-form';
 import type { Login } from '../types';
+import { useSubmitLogin } from '../api';
+import { useNavigate } from '@tanstack/react-router';
+import { setCookie } from '@/shared/utils';
 
 export default function LoginForm() {
   const { register, handleSubmit } = useForm<Login>();
+  const { mutate: login } = useSubmitLogin();
+  const navigate = useNavigate();
 
   const onSubmit = (data: Login) => {
-    console.log(data);
+    login(data, {
+      onSuccess: (data) => {
+        setCookie('accessToken', data.accessToken, 7);
+        setCookie('refreshToken', data.refreshToken, 7);
+        navigate({ to: PATH.HOME });
+      },
+      onError: () => {
+        alert('로그인에 실패했어요!');
+      },
+    });
   };
 
   return (

--- a/src/widgets/register/api/index.ts
+++ b/src/widgets/register/api/index.ts
@@ -1,0 +1,1 @@
+export * from './submitRegister';

--- a/src/widgets/register/api/submitRegister.ts
+++ b/src/widgets/register/api/submitRegister.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import type { Register } from '../types';
+import { post, REQUEST } from '@/shared/api';
+
+const submitRegister = async (data: Register) => {
+  const response = await post<Register>({
+    request: REQUEST.REGISTER,
+    data: data,
+  });
+  return response.data;
+};
+
+export const useSubmitRegister = () => {
+  return useMutation({
+    mutationFn: submitRegister,
+  });
+};

--- a/src/widgets/register/types/index.ts
+++ b/src/widgets/register/types/index.ts
@@ -1,0 +1,1 @@
+export * from './register';

--- a/src/widgets/register/types/register.ts
+++ b/src/widgets/register/types/register.ts
@@ -1,0 +1,7 @@
+export type Register = {
+  email: string;
+  password: string;
+  username: string;
+  nickname: string;
+  birthday: string;
+};

--- a/src/widgets/register/ui/RegisterForm.tsx
+++ b/src/widgets/register/ui/RegisterForm.tsx
@@ -3,26 +3,53 @@ import Button from '@/shared/components/Button';
 
 import { PATH } from '@/shared/constants';
 import { authForm, authFormAtag, authFormButton, authFormPtag, authFormWrapper } from '@/shared/styles';
+import { useForm } from 'react-hook-form';
+import type { Register } from '../types';
+import { useSubmitRegister } from '../api';
+import { useNavigate } from '@tanstack/react-router';
 
 export default function RegisterForm() {
+  const { register, handleSubmit } = useForm<Register>();
+  const { mutate: submitRegister } = useSubmitRegister();
+  const navigate = useNavigate();
+
+  const onSubmit = (data: Register) => {
+    submitRegister(data, {
+      onSuccess: () => {
+        navigate({ to: PATH.LOGIN });
+      },
+      onError: () => {
+        alert('회원가입에 실패했어요!');
+      },
+    });
+  };
+
   return (
-    <form className={authFormWrapper}>
+    <form className={authFormWrapper} onSubmit={handleSubmit(onSubmit)}>
       <div className={authForm}>
-        <FormInput title='이메일' type='email' />
+        <FormInput title='이메일' type='email' {...register('email', { required: true })} />
         <FormInput
           title='별명'
           required={false}
+          {...register('nickname', { required: false })}
           description='다른 회원에게 표시되는 이름이에요. 특수 문자와 이모지를 사용할 수 있어요.'
         />
-        <FormInput title='사용자명' type='text' description='숫자, 문자, 밑줄 _, 마침표만 사용할 수 있습니다.' />
-        <FormInput title='비밀번호' type='password' />
-        <FormInput title='생년월일' />
+        <FormInput
+          title='사용자명'
+          type='text'
+          description='숫자, 문자, 밑줄 _, 마침표만 사용할 수 있습니다.'
+          {...register('username', { required: true })}
+        />
+        <FormInput title='비밀번호' type='password' {...register('password', { required: true })} />
+        <FormInput title='생년월일' placeholder='YYYY-MM-DD' {...register('birthday', { required: true })} />
         <p className={authFormPtag}>
           <span>"계정 만들기"를 클릭하면 Discord의</span> <a className={authFormAtag}>이용 약관</a>에 동의하며{' '}
           <a className={authFormAtag}>개인정보 보호 정책</a>을 읽었음을 확인하는 것으로 간주됩니다.
         </p>
       </div>
-      <Button className={authFormButton}>계정 만들기</Button>
+      <Button type='submit' className={authFormButton}>
+        계정 만들기
+      </Button>
       <a href={PATH.LOGIN} className={authFormAtag}>
         이미 계정이 있나요? 로그인하세요
       </a>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> close #5

## 📝 작업 내용

> 로그인, 회원가입을 연동했습니다.
- `fetchLoginStatus` 함수를 통해 로그인 상태 확인 가능합니다.
- `cookie.ts` 내부에 정의된 유틸 함수들을 통해 쿠키 값을 가져오거나 지정, 삭제할 수 있습니다.
- authorization이 자동으로 적용되는 `shared/api/user.ts` 내부 메서드 `userGet`, `userPost`, `userPut` 등을 통해 authorization 헤더를 직접 작성하지 않아도 인가처리된 요청을 보낼 수 있습니다. 해당 메서드 사용해서 데이터 패칭 진행해주세요!

## 📸 스크린샷
